### PR TITLE
Make kernel-tools and kernel-tools-debuginfo option

### DIFF
--- a/tasks/install-RedHat-7.yml
+++ b/tasks/install-RedHat-7.yml
@@ -66,7 +66,7 @@
     - name: kernel
       when: true
     - name: "kernel-tools"
-      when: true
+      when: "{{ install_kernel_tools | bool }}"
       downgrade: true
     - name: kernel-devel
       when: "{{ install_kernel_headers | bool }}"
@@ -77,7 +77,7 @@
       when: "{{ install_kernel_debuginfo | bool }}"
       downgrade: true
     - name: kernel-tools-debuginfo
-      when: "{{ install_kernel_debuginfo | bool }}"
+      when: "{{ install_kernel_tools | bool and install_kernel_debuginfo | bool }}"
       downgrade: true
     - name: perf
       when: "{{ install_perf | bool }}"


### PR DESCRIPTION
The whamcloud Lustre repos for 2.12.7 don't include the above repos. They don't seem to be needed either so this PR makes them optional to allow this role to install kernel packages from that repo.